### PR TITLE
Load nukkit.yml first before plugin.yml for plugin compatibility

### DIFF
--- a/src/main/java/cn/nukkit/plugin/JavaPluginLoader.java
+++ b/src/main/java/cn/nukkit/plugin/JavaPluginLoader.java
@@ -80,9 +80,12 @@ public class JavaPluginLoader implements PluginLoader {
         try (JarFile jar = new JarFile(file)) {
             JarEntry entry = jar.getJarEntry("server.properties");
             if (entry == null) {
-                entry = jar.getJarEntry("plugin.yml");
+                entry = jar.getJarEntry("nukkit.yml");
                 if (entry == null) {
-                    return null;
+                    entry = jar.getJarEntry("plugin.yml");
+                    if (entry == null) {
+                        return null;
+                    }
                 }
             }
             try (InputStream stream = jar.getInputStream(entry)) {


### PR DESCRIPTION
Load nukkit.yml first before plugin.yml for plugin compatibility. For example, https://github.com/plan-player-analytics/Plan/issues/1561.