### PR TITLE
Fix the flow speed of lava in nether

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockLava.java
+++ b/src/main/java/cn/nukkit/block/BlockLava.java
@@ -149,6 +149,9 @@ public class BlockLava extends BlockLiquid {
     
     @Override
     public int tickRate() {
+        if (this.level.getDimension() == Level.DIMENSION_NETHER) {
+            return 10;
+        }
         return 30;
     }
 


### PR DESCRIPTION
Chinese wiki is 10 ticks, but English wiki is 5 ticks
But I test in a single machine (vanilla?), I think magma flow speed is not so fast
So I used 10 tick
(Google Translate)