### PR TITLE
ignore if event is cancelled

### DIFF
--- a/src/main/java/cn/nukkit/entity/BaseEntity.java
+++ b/src/main/java/cn/nukkit/entity/BaseEntity.java
@@ -200,8 +200,11 @@ public abstract class BaseEntity extends EntityCreature implements EntityAgeable
 
         super.attack(source);
 
-        this.target = null;
-        this.stayTime = 0;
+        if(!source.isCancelled()){
+            this.target = null;
+            this.stayTime = 0;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
this prevents movement changes while the entity is moving and getting damaged while the event is cancelled it can cause unexpected behaviors if not